### PR TITLE
PCT-11261 | Add Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     },
     "require": {
         "php": "^7.4 || ^8.0.2",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0"
+        "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0"
     }
 }


### PR DESCRIPTION
Widens illuminate/support constraint to include ^11.0. No code changes required; simple framework-version compatibility bump for the L10 → L13 upgrade project.